### PR TITLE
Use FirstOrDefault to avoid exception if member not found

### DIFF
--- a/Extensions/AttributeExtensions.cs
+++ b/Extensions/AttributeExtensions.cs
@@ -144,8 +144,8 @@ public static class AttributeExtensions
 
 		var attribute = value.GetType()
 			.GetMember(memberName)
-			.First()
-			.GetCustomAttribute<TAttribute>();
+			.FirstOrDefault()
+			?.GetCustomAttribute<TAttribute>();
 
 		return attribute;
 	}

--- a/easy-core.csproj
+++ b/easy-core.csproj
@@ -8,9 +8,9 @@
 		<Authors>NF Software Inc.</Authors>
 		<Company>NF Software Inc.</Company>
 		<Copyright>Copyright 2024 $(Company)</Copyright>
-		<Version>10.0.0</Version>
-		<AssemblyVersion>10.0.0.0</AssemblyVersion>
-		<FileVersion>10.0.0.0</FileVersion>
+		<Version>10.0.1</Version>
+		<AssemblyVersion>10.0.1.0</AssemblyVersion>
+		<FileVersion>10.0.1.0</FileVersion>
 		<PackageId>Easy.Base</PackageId>
 		<PackageTags>library extensions converters tools</PackageTags>
 		<RepositoryUrl>https://github.com/NF-Software-Inc/easy-core</RepositoryUrl>
@@ -19,6 +19,7 @@
 			Contains basic functions and classes to simplify application development of modern applications.
 		</Description>
 		<PackageReleaseNotes>
+			10.0.1 Update GetValueAttribute to prevent exception
 			10.0.0 Add support for .NET 10.0
 
 			1.2.2 Add attribute validation classes and lexicon collection


### PR DESCRIPTION
Replaced First() with FirstOrDefault() and added null-conditional access when retrieving member attributes to prevent exceptions and safely return null if the member does not exist.

Issue reference: https://github.com/NF-Software-Inc/easy-core/issues/15